### PR TITLE
Persist url query

### DIFF
--- a/app/static/js/index.js
+++ b/app/static/js/index.js
@@ -175,7 +175,7 @@ function runSearch() {
     p.list.innerHTML = '';
     pagesLoaded = 0;
     pagesFinished = false;
-    window.history.pushState(nextState, "test", createUrl(criteria));
+    window.history.pushState(nextState, "Updated URL Search Query", createUrl(criteria));
     loadNextPage();
 }
 


### PR DESCRIPTION
So, as of right now, the URL updates on search, and it also updates the criteria variable when the page is loaded. However, I haven't figured out how to update the actual filter buttons to match what's in the URL search parameters. Might need some hints implementing this. 