### PR TITLE
Move filters next to search bar

### DIFF
--- a/app/static/css/controls.css
+++ b/app/static/css/controls.css
@@ -7,6 +7,7 @@
 }
 
 .filters {
+    display: inline-block;
 }
 #clear_filters {
     margin-top: 8px;


### PR DESCRIPTION
This moves the filters (class year, birth month/day etc) to next to the search bar instead of on the line below by taking out the filters div.