### PR TITLE
Update About.html to include other apps using Yalies

### DIFF
--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -3,6 +3,9 @@
 {% block content %}
 <h1>About</h1>
 <p>Yalies is a website that provides data on the Yale student body. It combines data from <a href="https://students.yale.edu/facebook">Yale Face Book</a> and <a href="https://directory.yale.edu">Yale Directory</a>, with enhanced design, user experience, and security. It uses only data that Yale makes public. To learn how to remove your data from Yale's publicly published data set, see <a href="/hide_me">here</a>.</p>
+<h3>API</h3>
+<p>Yalies also provides an <a href="/apidocs">API</a> for student developers!</p>
+<p>The API powers numerous student projects and university services, including <a href="https://coursetable.com">CourseTable</a>, <a href="https://yalemenus.com">Yale Menus</a>, <a href="https://rdb.yale.edu">Yale Research Database (RDB)</a>, <a href="https://yaledailynews.com/blog/2020/12/03/40-2-percent-of-returning-student-athletes-take-leaves-of-absence-this-fall">Yale Daily News</a>, <a href="https://yalies.me">Yalies.me</a>, <a href="https://mailyale.com">MailYale</a>, <a href="https://comethru.io">Comethru</a>, <a href="https://ypost.app">YPost</a>, <a href="https://github.com/ErikBoesen/yale">yale CLI</a>, <a href="https://yaledailynews.com/blog/2021/02/11/ship-lets-yalies-play-matchmaker-with-peers">Ship</a>, <a href="https://www.internships.yesatyale.org/">YES Internships</a>, </a>students in S&DS 315 and CPSC 490, and more.</p>
 <h3 name="source_code">Source Code</h3>
 <p>You may access the source code of this website <a href="https://github.com/Yalies/api">on GitHub</a>.</p>
 <h3 name="author">Author</h3>


### PR DESCRIPTION
## Description

<!-- Replace the line below with the issue number your PR addresses. -->
Fixes #230 

Added the list of other apps that use Yalies.io, including links, to the About page. The list of apps was obtained directly from the home page that shows up prior to logging in. Note: some of the links don't work but they're still there


Include screenshots and/or videos!
<img width="1504" alt="Screenshot 2024-03-01 at 4 37 16 PM" src="https://github.com/Yalies/api/assets/46690141/eb449e19-af36-4205-9989-5430b0eef816">


## Checklist
- [x] I have thoroughly tested my code
- [x] I have considered security and privacy implications of my changes
- [x] I have added one other developer, @ErikBoesen, and the Yalies Team Lead as Reviewers
