### PR TITLE
Keyboard shortcut to focus search bar

### DIFF
--- a/app/static/js/index.js
+++ b/app/static/js/index.js
@@ -19,12 +19,22 @@ let p = {
 //////////////
 // Controls //
 //////////////
-query.onkeyup = function (e) {
-	if (e.keyCode === 13) {
+p.query.onkeyup = function (e) {
+	if (e.key === "Enter") {
 		e.preventDefault();
 		p.submit.click();
 	}
 };
+
+document.onkeydown = function (e) {
+	// No-op if focus is not on the body (i.e. user is typing in a textbox)
+	if (e.target !== document.body) return;
+
+	if(e.key === "/") {
+		p.query.focus();
+		e.preventDefault();
+	}
+}
 
 function collapseAllFilters() {
 	for (let filter of p.filters) {


### PR DESCRIPTION
## Description
- Fixes #236 
- Press <kbd>/</kbd> to focus the search bar
  - This key was chosen because it is the key you press on Google Search to focus the search bar
- Requested by Addison

## Checklist
- [x] I have thoroughly tested my code
- [x] I have considered security and privacy implications of my changes
- [x] I have added one other developer, @ErikBoesen, and the Yalies Team Lead as Reviewers
