### PR TITLE
Query exact if netID or UPI is typed

### DIFF
--- a/app/search.py
+++ b/app/search.py
@@ -1,4 +1,5 @@
 from app import db, elasticsearch
+from app.util import upi_regex, netid_regex
 
 
 def add_to_index(index, model):
@@ -94,8 +95,12 @@ def query_index_exact(index, query):
 class SearchableMixin:
     @classmethod
     def query_search(cls, expression):
-        # ids = query_index_exact(cls.__tablename__, expression)
-        ids = query_index_fuzzy(cls.__tablename__, expression)
+        ids = []
+        if netid_regex.match(expression) or upi_regex.match(expression):
+            ids = query_index_exact(cls.__tablename__, expression)
+        else:
+            ids = query_index_fuzzy(cls.__tablename__, expression)
+
         if len(ids) == 0:
             return cls.query.filter_by(id=0)
         when = []

--- a/app/util.py
+++ b/app/util.py
@@ -1,6 +1,7 @@
 from flask import jsonify, g
 from sqlalchemy.ext.declarative import DeclarativeMeta
 
+import re
 import json
 import datetime
 from functools import wraps
@@ -63,3 +64,6 @@ def to_json(model):
 
 def get_now():
     return int(datetime.datetime.utcnow().timestamp())
+
+netid_regex = re.compile(r'^[a-z]{2,}\d{1,4}$')
+upi_regex = re.compile(r'^\d{8}$')


### PR DESCRIPTION
## Description

Fixes #235 

An exact search for UPI and NetID is performed when a regex expression detects one of those values has been searched.

The behavior introduced is a strict improvement from the current behavior, since names do not contain numbers, and both regex patterns require the presence of numbers to match.

## Checklist
- [x] I have thoroughly tested my code
- [x] I have considered security and privacy implications of my changes
- [x] I have added one other developer, @ErikBoesen, and the Yalies Team Lead as Reviewers
